### PR TITLE
Handle score as optional in both AGS and Outcomes2 events, deleting grade if the value is None

### DIFF
--- a/src/main/java/net/paulgray/mocklti2/gradebook/GradebookService.java
+++ b/src/main/java/net/paulgray/mocklti2/gradebook/GradebookService.java
@@ -23,10 +23,11 @@ public interface GradebookService {
     void deleteLineItem(GradebookLineItem lineItem);
 
     Map<Integer, List<GradebookCell>> getGradebookCells(List<Integer> columnIds);
-    Optional<GradebookCell> getGradebookCell(Integer lineItemId, String resultSourcedId);
+    Optional<GradebookCell> getGradebookCell(Integer lineItemId, String studentId);
 
     GradebookCell addCell(GradebookCell cell);
-    GradebookCell getOrCreateGradebookCell(Integer lineItemId, String resultSourcedId, String source);
+    GradebookCell getOrCreateGradebookCell(Integer lineItemId, String studentId, String source);
     GradebookCell updateGradebookCell(GradebookCell gradebookCell);
+    void deleteCell(Integer lineItemId, String studentId);
 
 }

--- a/src/main/java/net/paulgray/mocklti2/gradebook/GradebookServiceHibernate.java
+++ b/src/main/java/net/paulgray/mocklti2/gradebook/GradebookServiceHibernate.java
@@ -151,4 +151,13 @@ public class GradebookServiceHibernate implements GradebookService {
         return (GradebookCell) crit.uniqueResult();
     }
 
+    @Override
+    @Transactional
+    public void deleteCell(Integer lineItemId, String studentId) {
+        Optional<GradebookCell> cell = getGradebookCell(lineItemId, studentId);
+        cell.ifPresent(
+            c -> sessionFactory.getCurrentSession().delete(c)
+        );
+    }
+
 }

--- a/src/main/scala/net/paulgray/mocklti2/tools/GradebooksService.scala
+++ b/src/main/scala/net/paulgray/mocklti2/tools/GradebooksService.scala
@@ -20,6 +20,8 @@ trait GradebooksService {
 
   def getCell(lineItemId: Integer, studentId: String): Option[GradebookCell]
 
+  def deleteCell(lineItemId: Integer, studentId: String): Unit
+
   def deleteGradebook(id: Integer): Unit
 
 }

--- a/src/main/scala/net/paulgray/mocklti2/tools/HibernateGradebooksService.scala
+++ b/src/main/scala/net/paulgray/mocklti2/tools/HibernateGradebooksService.scala
@@ -58,6 +58,12 @@ class HibernateGradebooksService extends GradebooksService {
   override def createOrUpdateCell(gradebookCell: GradebookCell): Unit =
     sessionFactory.getCurrentSession.saveOrUpdate(gradebookCell)
 
+  override def deleteCell(lineItemId: Integer, studentId: String): Unit = {
+    getCell(lineItemId, studentId).foreach(c => {
+      sessionFactory.getCurrentSession.delete(c)
+    })
+  }
+
   @Transactional
   override def getColumns(gradebook: Gradebook, page: Page): PagedResults[GradebookLineItem] =
     sessionFactory.getCurrentSession.createCriteria(classOf[GradebookLineItem])


### PR DESCRIPTION
Per the LTI specs on https://www.imsglobal.org/spec/lti-ags/v2p0/#scoregiven-and-scoremaximum

"When scoreGiven is not present or null, this indicates there is presently no score for that user, and the platform should clear any previous score value it may have previously received from the tool and stored for that user and line item."

This documentation is specifically refers to the AGS spec, but this idea is also applied to Outcomes 2.0. In the case of a None/null response, the grade is removed from the gradebook, and not set to 0.